### PR TITLE
Add prettier dependency, simplify eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,24 +23,7 @@
     "@typescript-eslint"
   ],
   "rules": {
-    "comma-dangle": [
-      "error",
-      "always-multiline"
-    ],
-    "comma-spacing": "off",
-    "@typescript-eslint/comma-spacing": [
-      "error"
-    ],
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-floating-promises": [
-      "error"
-    ],
-    "semi": "off",
-    "@typescript-eslint/semi": [
-      "error"
-    ],
-    "@typescript-eslint/member-delimiter-style": [
-      "error"
-    ]
+    "@typescript-eslint/no-floating-promises": ["error"]
   }
 }

--- a/lib/events/lintOnPush.ts
+++ b/lib/events/lintOnPush.ts
@@ -205,10 +205,7 @@ const RunEslintStep: LintStep = {
         const prefix = `${params.project.path()}/`;
 
         const lines = [];
-        const argsString = args
-            .join(" ")
-            .split(`${params.project.path()}/`)
-            .join("");
+        const argsString = args.join(" ").split(`${params.project.path()}/`).join("");
         await ctx.audit.log(`Running ESLint with: $ eslint ${argsString}`);
 
         // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,6 +1242,14 @@
         "tslib": "1.10.0",
         "upper-case": "2.0.1",
         "valid-url": "1.0.9"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
+        }
       }
     },
     "@graphql-codegen/core": {
@@ -8148,9 +8156,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mocha": "^7.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "supervisor": "^0.12.0",
     "ts-node": "^8.10.2",


### PR DESCRIPTION
Add prettier as dev dependency.  Things worked previously because
it was included transitively.

Remove eslint rules that are redundant with those provided by
prettier/recommended.

Delint.